### PR TITLE
Bugfix/assets cdn

### DIFF
--- a/app/assets/stylesheets/spina/_forms.sass
+++ b/app/assets/stylesheets/spina/_forms.sass
@@ -804,7 +804,7 @@ input.datepicker
     z-index: 9
 
   .customfile-button
-    display: none
+    display: block
 
 .document-select
   ul

--- a/app/assets/stylesheets/spina/_gallery.sass
+++ b/app/assets/stylesheets/spina/_gallery.sass
@@ -262,7 +262,7 @@
     z-index: 9
 
   .customfile-button
-    display: none
+    display: block
 
   .new_photo label, .new_image label
     color: #999

--- a/app/views/spina/admin/images/_image.html.haml
+++ b/app/views/spina/admin/images/_image.html.haml
@@ -7,4 +7,4 @@
     = radio_button_tag :image_id, image.id
     = check_box_tag 'image_ids[]', image.id, image.id.to_s.try(:in?, params[:selected_ids].to_a)
 
-  = image_tag Rails.application.routes.url_helpers.rails_representation_url(image.file.variant(resize: "300x300").processed, only_path: true)
+  %img{:alt => "", :src => Rails.application.routes.url_helpers.rails_representation_url(image.file.variant(resize: "300x300").processed, only_path: true) }

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,3 +1,3 @@
 module Spina
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,3 +1,3 @@
 module Spina
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,3 +1,3 @@
 module Spina
-  VERSION = "1.1.4"
+  VERSION = "1.1.3"
 end

--- a/vendor/assets/javascripts/spina/jquery.customfileinput.js
+++ b/vendor/assets/javascripts/spina/jquery.customfileinput.js
@@ -58,7 +58,7 @@ $.fn.customFileInput = function(){
   //create custom control container
   var upload = $('<div class="customfile"></div>');
   //create custom control button
-  var uploadButton = $('<span class="customfile-button" aria-hidden="true">Subir documento</span>').appendTo(upload);
+  var uploadButton = $('<span class="customfile-button" aria-hidden="true">Subir archivo</span>').appendTo(upload);
   //create custom control feedback
   var uploadFeedback = $('<span class="customfile-feedback" aria-hidden="true">Geen bestand geselecteerd...</span>').appendTo(upload);
   

--- a/vendor/assets/javascripts/spina/jquery.customfileinput.js
+++ b/vendor/assets/javascripts/spina/jquery.customfileinput.js
@@ -58,7 +58,7 @@ $.fn.customFileInput = function(){
   //create custom control container
   var upload = $('<div class="customfile"></div>');
   //create custom control button
-  var uploadButton = $('<span class="customfile-button" aria-hidden="true">voeg foto toe</span>').appendTo(upload);
+  var uploadButton = $('<span class="customfile-button" aria-hidden="true">Subir documento</span>').appendTo(upload);
   //create custom control feedback
   var uploadFeedback = $('<span class="customfile-feedback" aria-hidden="true">Geen bestand geselecteerd...</span>').appendTo(upload);
   


### PR DESCRIPTION
image_tag toma el cuenta el contenido de la configuración de asset_host y trata de mostrar las imágenes desde cloudfront en vez de active storage(S3)